### PR TITLE
Adding full pre-release version comparison support.

### DIFF
--- a/semver/semver_test.go
+++ b/semver/semver_test.go
@@ -42,6 +42,14 @@ var fixtures = []fixture{
 	fixture{"1.2.3-a.b", "1.2.3-a.5"},
 	fixture{"1.2.3-a.b", "1.2.3-a"},
 	fixture{"1.2.3-a.b.c.10.d.5", "1.2.3-a.b.c.5.d.100"},
+	fixture{"1.0.0", "1.0.0-rc.1"},
+	fixture{"1.0.0-rc.2", "1.0.0-rc.1"},
+	fixture{"1.0.0-rc.1", "1.0.0-beta.11"},
+	fixture{"1.0.0-beta.11", "1.0.0-beta.2"},
+	fixture{"1.0.0-beta.2", "1.0.0-beta"},
+	fixture{"1.0.0-beta", "1.0.0-alpha.beta"},
+	fixture{"1.0.0-alpha.beta", "1.0.0-alpha.1"},
+	fixture{"1.0.0-alpha.1", "1.0.0-alpha"},
 }
 
 func TestCompare(t *testing.T) {

--- a/semver/sort.go
+++ b/semver/sort.go
@@ -1,24 +1,24 @@
 package semver
 
 import (
-    "sort"
+	"sort"
 )
 
 type Versions []*Version
 
 func (s Versions) Len() int {
-    return len(s)
+	return len(s)
 }
 
 func (s Versions) Swap(i, j int) {
-    s[i], s[j] = s[j], s[i]
+	s[i], s[j] = s[j], s[i]
 }
 
 func (s Versions) Less(i, j int) bool {
-    return s[i].LessThan(*s[j])
+	return s[i].LessThan(*s[j])
 }
 
 // Sort sorts the given slice of Version
 func Sort(versions []*Version) {
-    sort.Sort(Versions(versions))
+	sort.Sort(Versions(versions))
 }


### PR DESCRIPTION
Hey there CoreOS folks,

I was toying with this library and I had the need to do a little more accurate
pre-release comparisons. I saw the TODO and decided to bite if off. I started by
adding the values at the bottom of secion 11 here: http://semver.org to the
tests and change
https://github.com/amerine/go-semver/blob/29b30448e895b3a00419003f027196bf17ca2a58/semver/semver.go#L99
to actually check versionB.

This resulted in some failures that I could work against. The solution here
needs to check for ints and strings based on the precedence rules that semver
prefers. I was hoping for a cleaner way of doing that, but nothing I threw at
the problem was quicker than what I'm using here (manual type conversions and
leaning on the success/failure of that to decide where to proceed.)

:heart: Amerine
