### PR TITLE
Removing done 'pre-release' TODO from readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,4 +29,3 @@ $ go run example.go 5.2.3 3.2.1
 ## TODO
 
 - Richer comparision operations
-- Full compliance with semver.org rules on pre-release parsing


### PR DESCRIPTION
I implemented the full pre-release spec from semver.org, but forgot to remove
the TODO from the README. This just removes the line from the README.
