### PR TITLE
Add functions to "Bump" major, minor, and patch

### DIFF
--- a/semver/semver.go
+++ b/semver/semver.go
@@ -178,28 +178,25 @@ func recursivePreReleaseCompare(versionA []string, versionB []string) int {
 }
 
 // BumpMajor increments the Major field by 1 and resets all other fields to their default values
-func (v *Version) BumpMajor() *Version {
+func (v *Version) BumpMajor() {
 	v.Major += 1
 	v.Minor = 0
 	v.Patch = 0
 	v.PreRelease = PreRelease("")
 	v.Metadata = ""
-	return v
 }
 
 // BumpMinor increments the Minor field by 1 and resets all other fields to their default values
-func (v *Version) BumpMinor() *Version {
+func (v *Version) BumpMinor() {
 	v.Minor += 1
 	v.Patch = 0
 	v.PreRelease = PreRelease("")
 	v.Metadata = ""
-	return v
 }
 
 // BumpPatch increments the Patch field by 1 and resets all other fields to their default values
-func (v *Version) BumpPatch() *Version {
+func (v *Version) BumpPatch() {
 	v.Patch += 1
 	v.PreRelease = PreRelease("")
 	v.Metadata = ""
-	return v
 }

--- a/semver/semver_test.go
+++ b/semver/semver_test.go
@@ -126,58 +126,62 @@ func TestSort(t *testing.T) {
 
 func TestBumpMajor(t *testing.T) {
 	version, _ := NewVersion("1.0.0")
-	bumped := version.BumpMajor()
-	if bumped.Major != 2 {
-		t.Fatalf("bumping major on 1.0.0 resulted in %v", bumped)
+	version.BumpMajor()
+	if version.Major != 2 {
+		t.Fatalf("bumping major on 1.0.0 resulted in %v", version)
 	}
 
 	version, _ = NewVersion("1.5.2")
-	if bumped.Minor != 0 && bumped.Patch != 0 {
-		t.Fatalf("bumping major on 1.5.2 resulted in %v", bumped)
+	version.BumpMajor()
+	if version.Minor != 0 && version.Patch != 0 {
+		t.Fatalf("bumping major on 1.5.2 resulted in %v", version)
 	}
 
 	version, _ = NewVersion("1.0.0+build.1-alpha.1")
-	if bumped.PreRelease != "" && bumped.PreRelease != "" {
-		t.Fatalf("bumping major on 1.0.0+build.1-alpha.1 resulted in %v", bumped)
+	version.BumpMajor()
+	if version.PreRelease != "" && version.PreRelease != "" {
+		t.Fatalf("bumping major on 1.0.0+build.1-alpha.1 resulted in %v", version)
 	}
 }
 
 func TestBumpMinor(t *testing.T) {
 	version, _ := NewVersion("1.0.0")
-	bumped := version.BumpMinor()
+	version.BumpMinor()
 
-	if bumped.Major != 1 {
-		t.Fatalf("bumping minor on 1.0.0 resulted in %v", bumped)
+	if version.Major != 1 {
+		t.Fatalf("bumping minor on 1.0.0 resulted in %v", version)
 	}
 
-	if bumped.Minor != 1 {
-		t.Fatalf("bumping major on 1.0.0 resulted in %v", bumped)
+	if version.Minor != 1 {
+		t.Fatalf("bumping major on 1.0.0 resulted in %v", version)
 	}
 
 	version, _ = NewVersion("1.0.0+build.1-alpha.1")
-	if bumped.PreRelease != "" && bumped.PreRelease != "" {
-		t.Fatalf("bumping major on 1.0.0+build.1-alpha.1 resulted in %v", bumped)
+	version.BumpMinor()
+	if version.PreRelease != "" && version.PreRelease != "" {
+		t.Fatalf("bumping major on 1.0.0+build.1-alpha.1 resulted in %v", version)
 	}
 }
 
 func TestBumpPatch(t *testing.T) {
 	version, _ := NewVersion("1.0.0")
-	bumped := version.BumpPatch()
+	version.BumpPatch()
 
-	if bumped.Major != 1 {
-		t.Fatalf("bumping minor on 1.0.0 resulted in %v", bumped)
+	if version.Major != 1 {
+		t.Fatalf("bumping minor on 1.0.0 resulted in %v", version)
 	}
 
-	if bumped.Minor != 0 {
-		t.Fatalf("bumping major on 1.0.0 resulted in %v", bumped)
+	if version.Minor != 0 {
+		t.Fatalf("bumping major on 1.0.0 resulted in %v", version)
 	}
 
-	if bumped.Patch != 1 {
-		t.Fatalf("bumping major on 1.0.0 resulted in %v", bumped)
+	if version.Patch != 1 {
+		t.Fatalf("bumping major on 1.0.0 resulted in %v", version)
 	}
 
 	version, _ = NewVersion("1.0.0+build.1-alpha.1")
-	if bumped.PreRelease != "" && bumped.PreRelease != "" {
-		t.Fatalf("bumping major on 1.0.0+build.1-alpha.1 resulted in %v", bumped)
+	version.BumpPatch()
+	if version.PreRelease != "" && version.PreRelease != "" {
+		t.Fatalf("bumping major on 1.0.0+build.1-alpha.1 resulted in %v", version)
 	}
 }


### PR DESCRIPTION
Hello CoreOS,

A coworker of mine pointed me to using this awesome library in a project we are writing. Our code is currently doing the work in this pull, but I felt like the code might be useful for this library.

Basically, we wanted to add some additional functions on a `semver.Version`. Particularly, we want to be able to "bump" (increment) the three major components of the Version.

`BumpMajor()` will bump the Major field and reset all the others: `1.0.0 ==> 2.0.0`
`BumpMinor()` will bump the Minor field and reset the fields below Minor: `1.0.0 ==> 1.1.0`
`BumpPatch()` will bump the Patch field and reset the fields below Patch: `1.0.0 ==> 1.0.1`
All 3 functions reset the `Prerelease` and `Metadata` fields.

We think this will be useful from a library perspective when a user wants to move a Version through the SemVer lifecycle. All those details are described in #'s 6,7,8 of the spec:

_Patch version MUST be reset to 0 when minor version is incremented._
_Patch and minor version MUST be reset to 0 when major version is incremented._

Please let me know what you think!
