### PR TITLE
Fix when a version is of the form x.y.z.a-something-more.

### DIFF
--- a/semver/semver.go
+++ b/semver/semver.go
@@ -50,9 +50,9 @@ func NewVersion(version string) (*Version, error) {
 	v.Metadata = splitOff(&version, "+")
 	v.PreRelease = PreRelease(splitOff(&version, "-"))
 
-	dotParts := strings.SplitN(version, ".", 3)
+	dotParts := strings.SplitN(version, ".", -1)
 
-	if len(dotParts) != 3 {
+	if len(dotParts) < 3 {
 		return nil, errors.New(fmt.Sprintf("%s is not in dotted-tri format", version))
 	}
 


### PR DESCRIPTION
Fix when a version is of the form x.y.z.a-something-more, may be due to additional distro added tags.
This does not affect x.y.z (major.minor.patch) versioning.