### PR TITLE
Consistently use *Version in exported API (fixes #20)

### DIFF
--- a/semver/semver.go
+++ b/semver/semver.go
@@ -94,7 +94,7 @@ func (v *Version) Set(version string) error {
 	return nil
 }
 
-func (v Version) String() string {
+func (v *Version) String() string {
 	var buffer bytes.Buffer
 
 	fmt.Fprintf(&buffer, "%d.%d.%d", v.Major, v.Minor, v.Patch)
@@ -118,7 +118,7 @@ func (v *Version) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return v.Set(data)
 }
 
-func (v Version) MarshalJSON() ([]byte, error) {
+func (v *Version) MarshalJSON() ([]byte, error) {
 	return []byte(`"` + v.String() + `"`), nil
 }
 
@@ -135,7 +135,7 @@ func (v *Version) UnmarshalJSON(data []byte) error {
 
 // Compare tests if v is less than, equal to, or greater than versionB,
 // returning -1, 0, or +1 respectively.
-func (v Version) Compare(versionB Version) int {
+func (v *Version) Compare(versionB *Version) int {
 	if cmp := recursiveCompare(v.Slice(), versionB.Slice()); cmp != 0 {
 		return cmp
 	}
@@ -143,17 +143,17 @@ func (v Version) Compare(versionB Version) int {
 }
 
 // Equal tests if v is equal to versionB.
-func (v Version) Equal(versionB Version) bool {
+func (v *Version) Equal(versionB *Version) bool {
 	return v.Compare(versionB) == 0
 }
 
 // LessThan tests if v is less than versionB.
-func (v Version) LessThan(versionB Version) bool {
+func (v *Version) LessThan(versionB *Version) bool {
 	return v.Compare(versionB) < 0
 }
 
 // Slice converts the comparable parts of the semver into a slice of integers.
-func (v Version) Slice() []int64 {
+func (v *Version) Slice() []int64 {
 	return []int64{v.Major, v.Minor, v.Patch}
 }
 
@@ -162,7 +162,7 @@ func (p PreRelease) Slice() []string {
 	return strings.Split(preRelease, ".")
 }
 
-func preReleaseCompare(versionA Version, versionB Version) int {
+func preReleaseCompare(versionA *Version, versionB *Version) int {
 	a := versionA.PreRelease
 	b := versionB.PreRelease
 

--- a/semver/semver_test.go
+++ b/semver/semver_test.go
@@ -86,22 +86,22 @@ func TestCompare(t *testing.T) {
 			t.Error(err)
 		}
 
-		if gt.LessThan(*lt) {
+		if gt.LessThan(lt) {
 			t.Errorf("%s should not be less than %s", gt, lt)
 		}
-		if gt.Equal(*lt) {
+		if gt.Equal(lt) {
 			t.Errorf("%s should not be equal to %s", gt, lt)
 		}
-		if gt.Compare(*lt) <= 0 {
+		if gt.Compare(lt) <= 0 {
 			t.Errorf("%s should be greater than %s", gt, lt)
 		}
-		if !lt.LessThan(*gt) {
+		if !lt.LessThan(gt) {
 			t.Errorf("%s should be less than %s", lt, gt)
 		}
-		if !lt.Equal(*lt) {
+		if !lt.Equal(lt) {
 			t.Errorf("%s should be equal to %s", lt, lt)
 		}
-		if lt.Compare(*gt) > 0 {
+		if lt.Compare(gt) > 0 {
 			t.Errorf("%s should not be greater than %s", lt, gt)
 		}
 	}
@@ -364,7 +364,7 @@ func ExampleVersion_LessThan() {
 	vA := New("1.2.3")
 	vB := New("3.2.1")
 
-	fmt.Printf("%s < %s == %t\n", vA, vB, vA.LessThan(*vB))
+	fmt.Printf("%s < %s == %t\n", vA, vB, vA.LessThan(vB))
 	// Output:
 	// 1.2.3 < 3.2.1 == true
 }

--- a/semver/sort.go
+++ b/semver/sort.go
@@ -29,7 +29,7 @@ func (s Versions) Swap(i, j int) {
 }
 
 func (s Versions) Less(i, j int) bool {
-	return s[i].LessThan(*s[j])
+	return s[i].LessThan(s[j])
 }
 
 // Sort sorts the given slice of Version


### PR DESCRIPTION
This pull request defines all exported methods on the Version type as taking a pointer receiver. Also, all exported methods that accept a version parameter now accept a `*Version`, which is what `New()` and `NewVersion()` already returned.

(As a side effect this addresses the weirdness that previously, `Version` implemented the `json.Marshaler` interface, while `*Version` implemented the `json.Unmarshaler` interface.)