### PR TITLE
fix pre-release mismatched alpha/numeric comparison

### DIFF
--- a/semver/semver.go
+++ b/semver/semver.go
@@ -224,6 +224,12 @@ func recursivePreReleaseCompare(versionA []string, versionB []string) int {
 		bInt = true
 	}
 
+	if aInt && !bInt {
+		return -1
+	} else if !aInt && bInt {
+		return 1
+	}
+
 	// Handle Integer Comparison
 	if aInt && bInt {
 		if aI > bI {

--- a/semver/semver.go
+++ b/semver/semver.go
@@ -224,6 +224,7 @@ func recursivePreReleaseCompare(versionA []string, versionB []string) int {
 		bInt = true
 	}
 
+	// Numeric identifiers always have lower precedence than non-numeric identifiers.
 	if aInt && !bInt {
 		return -1
 	} else if !aInt && bInt {

--- a/semver/semver_test.go
+++ b/semver/semver_test.go
@@ -72,6 +72,7 @@ var fixtures = []fixture{
 	fixture{"1.0.0-beta", "1.0.0-alpha.beta"},
 	fixture{"1.0.0-alpha.beta", "1.0.0-alpha.1"},
 	fixture{"1.0.0-alpha.1", "1.0.0-alpha"},
+	fixture{"1.2.3-rc.1-1-1hash", "1.2.3-rc.2"},
 }
 
 func TestCompare(t *testing.T) {


### PR DESCRIPTION
Comparing the versions i.e. `1.2.3-rc.2` and `1.2.3-rc.1-1-1hash` I intuitively expected the former to be greater than the latter. Unfortunately, a careful reading of the spec proves that not the case.

Inside http://semver.org/#spec-item-11: `Numeric identifiers always have lower precedence than non-numeric identifiers.`

This PR adds a test for this case, and fixes the behavior of `recursivePreReleaseCompare()`.

See https://github.com/npm/node-semver/issues/182 and https://github.com/hashicorp/go-version/pull/25