### PR TITLE
Add pre-release and metadata identifiers validation

### DIFF
--- a/semver/semver.go
+++ b/semver/semver.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"regexp"
 	"strconv"
 	"strings"
 )
@@ -74,6 +75,14 @@ func (v *Version) Set(version string) error {
 
 	if len(dotParts) != 3 {
 		return fmt.Errorf("%s is not in dotted-tri format", version)
+	}
+
+	if err := validateIdentifier(string(preRelease)); err != nil {
+		return fmt.Errorf("failed to validate pre-release: %v", err)
+	}
+
+	if err := validateIdentifier(metadata); err != nil {
+		return fmt.Errorf("failed to validate metadata: %v", err)
 	}
 
 	parsed := make([]int64, 3, 3)
@@ -273,3 +282,15 @@ func (v *Version) BumpPatch() {
 	v.PreRelease = PreRelease("")
 	v.Metadata = ""
 }
+
+// validateIdentifier makes sure the provided identifier satisfies semver spec
+func validateIdentifier(id string) error {
+	if id != "" && !reIdentifier.MatchString(id) {
+		return fmt.Errorf("%s is not a valid semver identifier", id)
+	}
+	return nil
+}
+
+// reIdentifier is a regular expression used to check that pre-release and metadata
+// identifiers satisfy the spec requirements
+var reIdentifier = regexp.MustCompile(`^[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*$`)

--- a/semver/semver_test.go
+++ b/semver/semver_test.go
@@ -339,6 +339,8 @@ func TestBadInput(t *testing.T) {
 		"0x1.3.4",
 		"-1.2.3",
 		"1.2.3.4",
+		"0.88.0-11_e4e5dcabb",
+		"0.88.0+11_e4e5dcabb",
 	}
 	for _, b := range bad {
 		if _, err := NewVersion(b); err == nil {


### PR DESCRIPTION
Currently anything is accepted as metadata/pre-release while the spec has some restrictions on them:

http://semver.org/#spec-item-9
> A pre-release version MAY be denoted by appending a hyphen and a series of dot separated identifiers immediately following the patch version. Identifiers MUST comprise only ASCII alphanumerics and hyphen [0-9A-Za-z-].

http://semver.org/#spec-item-10
> Build metadata MAY be denoted by appending a plus sign and a series of dot separated identifiers immediately following the patch or pre-release version. Identifiers MUST comprise only ASCII alphanumerics and hyphen [0-9A-Za-z-].
