### PR TITLE
github/dependabot: Drop gomod updates, add GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,16 @@
-# Maintained in https://github.com/coreos/repo-templates
-# Do not edit downstream.
+# Updates are grouped together by ecosystem in a single PR. An update can be
+# removed from a combined update PR via comments to dependabot:
+# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/managing-pull-requests-for-dependency-updates#managing-dependabot-pull-requests-for-grouped-updates-with-comment-commands
 
 version: 2
 updates:
-  - package-ecosystem: gomod
-    directory: /
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: weekly
-    open-pull-requests-limit: 10
-    labels:
-      - dependency
+      interval: "weekly"
+    labels: ["skip-notes"]
+    open-pull-requests-limit: 3
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
See: https://github.com/coreos/repo-templates/issues/340
See: https://github.com/coreos/repo-templates/pull/352